### PR TITLE
feat: implementar módulo terraform con validación HCL2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ badges/
 .terraform/
 terraform.tfstate*
 *.tfvars
+.terraform.lock.hcl

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -2,7 +2,7 @@
 STAGED=$(git diff --cached --name-only) #obtiene los archivos que estan preparados para el commit
 
 for file in $STAGED; do
-    if [[ ! $file =~ \.(py|sh|tf|tfvars|md|svg|txt)$ && $file == *.* ]]; then #verifica que los archivos tengan una extension permitida
+    if [[ ! $file =~ \.(py|sh|tf|tfvars|md|svg|txt)$ && $file == *.* && $file != ".gitignore" ]]; then #verifica que los archivos tengan una extension permitida, permite .gitignore
         echo "Solo se permiten archivos .py, .sh, .tf, .tfvars, .md, .svg .txt: $file"
         exit 1
     fi

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -1,0 +1,13 @@
+# Variable
+variable "environment" {
+  description = "Nombre del entorno"
+  type        = string
+  default     = "dev"
+}
+
+# Recurso null_resource
+resource "null_resource" "qa_platform_setup" {
+  triggers = {
+    environment = var.environment
+  }
+}

--- a/iac_tests/test_terraform_validation.py
+++ b/iac_tests/test_terraform_validation.py
@@ -1,0 +1,9 @@
+import hcl2
+
+
+def test_terraform_syntax_validation():
+    """Valida sintaxis HCL2 del archivo main.tf"""
+    with open("iac/main.tf", 'r') as file:
+        terraform_config = hcl2.load(file)
+    
+    assert terraform_config is not None

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ coverage==7.8.0
 exceptiongroup==1.2.2
 flake8==7.2.0
 iniconfig==2.1.0
+lark==1.2.2
 mccabe==0.7.0
 packaging==25.0
 parse==1.20.2
@@ -11,5 +12,6 @@ pycodestyle==2.13.0
 pyflakes==3.3.2
 pytest==8.3.5
 pytest-cov==6.1.1
+python-hcl2==7.2.1
 six==1.17.0
 tomli==2.2.1


### PR DESCRIPTION
## Implementación de módulo Terraform e infraestructura de testing

### Cambios realizados:

**Módulo Terraform (`iac/main.tf`)**
- Recurso `null_resource` para testing de infraestructura
- Variable configurable `environment` con valor por defecto
- Base funcional para workflows de IaC

**Testing HCL2 (`iac_tests/test_terraform_validation.py`)**
- Validación automática de sintaxis Terraform usando `python-hcl2`
- Integración con framework `pytest` existente
- Verificación de calidad de código de infraestructura

**Configuración del proyecto**
- Dependencias actualizadas: `python-hcl2` y `lark`
- `.gitignore` mejorado para archivos Terraform
- Hook `pre-commit` ajustado para archivos de configuración

Este PR corresponde al issue #6 (Crear modulo Terraform)