### PR TITLE
feat(iac): implementar módulo de variables Terraform

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -1,13 +1,8 @@
-# Variable
-variable "environment" {
-  description = "Nombre del entorno"
-  type        = string
-  default     = "dev"
-}
-
 # Recurso null_resource
 resource "null_resource" "qa_platform_setup" {
   triggers = {
-    environment = var.environment
+    environment  = var.environment
+    project_name = var.project_name
+    enable_debug = var.enable_debug ? "enabled" : "disabled"
   }
 }

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -2,7 +2,6 @@ variable "environment" {
   description = "Entorno de despliegue (dev, test, prod)"
   type        = string
   default     = "dev"
-
   validation {
     condition     = contains(["dev", "test", "prod"], var.environment)
     error_message = "El valor de environment debe ser 'dev', 'test', o 'prod'."

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -1,0 +1,22 @@
+variable "environment" {
+  description = "Entorno de despliegue (dev, test, prod)"
+  type        = string
+  default     = "dev"
+
+  validation {
+    condition     = contains(["dev", "test", "prod"], var.environment)
+    error_message = "El valor de environment debe ser 'dev', 'test', o 'prod'."
+  }
+}
+
+variable "project_name" {
+  description = "Nombre del proyecto para recursos y etiquetado"
+  type        = string
+  default     = "calidad-code"
+}
+
+variable "enable_debug" {
+  description = "Habilita funcionalidades de depuración"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Cambios realizados

### 1. Se crea archivo variables.tf con tres variables:
- `environment`: Para definir el entorno de despliegue (dev/test/prod)
- `project_name`: Para identificar el proyecto
- `enable_debug`: Para activar funcionalidades de depuración

### 2. Se actualiza main.tf:
- Se elimina la definición de variable local
- Se refactoriza el recurso null_resource para usar las variables del módulo

## Validación
- Se ha ejecutado terraform validate y no se reportan errores de sintaxis
- Se ha probado la inicialización del proyecto con terraform init sin problemas

## Resultado
```shell
(.venv) hoperrs@hoperrs:~/Escritorio/Plataforma-de-control-de-calidad-de-codigo-$ terraform validate
Success! The configuration is valid.
``` 

Esta PR corresponde a la issue #24 .