### PR TITLE
feat(iac): Implementar provisioner local y pruebas de variables Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ badges/
 terraform.tfstate*
 *.tfvars
 .terraform.lock.hcl
+*.txt

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -6,3 +6,21 @@ resource "null_resource" "qa_platform_setup" {
     enable_debug = var.enable_debug ? "enabled" : "disabled"
   }
 }
+
+# Recurso para crear archivo de prueba
+resource "null_resource" "file_creator" {
+  # Aseguramos que se ejecute después del recurso principal
+  depends_on = [null_resource.qa_platform_setup]
+
+  # Provisioner que crea un archivo de texto
+  provisioner "local-exec" {
+    command = <<-EOT
+      echo "Este archivo fue creado por Terraform como parte de las pruebas de infraestructura." > iac_dummy.txt
+      echo "Configuración de Infraestructura:" >> iac_dummy.txt
+      echo "- Entorno: ${var.environment}" >> iac_dummy.txt
+      echo "- Proyecto: ${var.project_name}" >> iac_dummy.txt
+      echo "- Debug: ${var.enable_debug ? "enabled" : "disabled"}" >> iac_dummy.txt
+      echo "- Timestamp: $(date)" >> iac_dummy.txt
+    EOT
+  }
+}

--- a/iac_tests/test_iac_variables.py
+++ b/iac_tests/test_iac_variables.py
@@ -1,0 +1,75 @@
+import hcl2
+import pytest
+
+from src.utils.list_utils import aplanar_lista
+from src.helpers.gestor_archivos import GestorArchivos
+
+
+"""Tests para validar las variables definidas en iac/variables.tf"""
+
+
+@pytest.fixture(scope="function")
+def variables_dict():
+    """Setup para cada test - inicializar gestor de archivos"""
+    ruta_variables = "iac/variables.tf"
+    gestor_archivos = GestorArchivos()
+    # Verificar que el archivo de variables existe
+    assert gestor_archivos.existe_archivo(ruta_variables)
+    with open(ruta_variables, 'r') as file:
+        terraform_config = hcl2.load(file)
+    # Verificar que la configuración de Terraform se cargó correctamente
+    assert "variable" in terraform_config
+    # Aplanar la lista de variables para facilitar el acceso
+    variables_dict = {}
+    variables_aplanadas = aplanar_lista(terraform_config["variable"])
+    for var_item in variables_aplanadas:
+        if isinstance(var_item, dict):
+            for var_name, var_config in var_item.items():
+                variables_dict[var_name] = var_config
+    return variables_dict
+
+
+@pytest.fixture(scope="function")
+def required_vars():
+    """Variables requeridas para los tests"""
+    return ["environment", "project_name", "enable_debug"]
+
+
+def test_variables_exist(variables_dict, required_vars):
+    """Verifica que existan las variables requeridas en variables.tf"""
+    # Verificar que existan las variables específicas
+    for var_name in required_vars:
+        assert var_name in variables_dict
+
+
+def test_variables_types(variables_dict):
+    """Verifica que las variables tengan los tipos correctos"""
+    # Verificar tipos de variables
+    expected_types = {
+        "environment": "string",
+        "project_name": "string",
+        "enable_debug": "bool"
+    }
+    for var_name, expected_type in expected_types.items():
+        assert var_name in variables_dict
+        assert "type" in variables_dict[var_name]
+        actual_type = variables_dict[var_name]["type"]
+        assert actual_type == expected_type
+
+
+def test_variables_defaults(variables_dict, required_vars):
+    """Verifica que las variables tengan valores predeterminados"""
+    for var_name in required_vars:
+        assert var_name in variables_dict
+        assert "default" in variables_dict[var_name]
+        default_value = variables_dict[var_name]["default"]
+        assert default_value or isinstance(default_value, bool)
+
+
+def test_variables_descriptions(variables_dict, required_vars):
+    """Verifica que todas las variables tengan descripciones"""
+    for var_name in required_vars:
+        assert var_name in variables_dict
+        assert "description" in variables_dict[var_name]
+        description = variables_dict[var_name]["description"]
+        assert description.strip()

--- a/iac_tests/test_terraform_validation.py
+++ b/iac_tests/test_terraform_validation.py
@@ -5,5 +5,4 @@ def test_terraform_syntax_validation():
     """Valida sintaxis HCL2 del archivo main.tf"""
     with open("iac/main.tf", 'r') as file:
         terraform_config = hcl2.load(file)
-    
     assert terraform_config is not None


### PR DESCRIPTION
Esta PR implementa dos funcionalidades relacionadas con la infraestructura como código:

1. Se añadió un recurso `null_resource` con un provisioner local que crea un archivo `iac_dummy.txt`
2. Se creó un script de prueba `test_iac_variables.py` que verifica la correcta definición de variables en `variables.tf`

## Cambios realizados

### Issue #25: Crear un recurso null_resource que use un provisioner local

- Agregado `null_resource.file_creator` en `iac/main.tf`
- Implementado provisioner `local-exec` que genera el archivo `iac_dummy.txt` con contenido de prueba
- Configurada dependencia con el recurso principal existente

### Issue #26: Crear un script test_iac_variables.py

- Creado `iac_tests/test_iac_variables.py` con funciones de prueba para:
  - Verificar existencia de variables requeridas
  - Validar que los tipos de variables sean correctos
  - Comprobar que existan valores por defecto no vacíos

## Instrucciones para probar

1. Ejecutar `cd iac && terraform init && terraform apply -auto-approve`
2. Verificar que se cree el archivo `iac_dummy.txt` en el directorio `iac/`
3. Ejecutar `pytest iac_tests/test_iac_variables.py` para validar las pruebas