### PR TITLE
feat: se implementa tests con markers xfail y skip

### DIFF
--- a/tests/test_list_utils.py
+++ b/tests/test_list_utils.py
@@ -1,5 +1,7 @@
 import pytest
 import src.utils.list_utils as list_utils
+import os
+import time
 
 
 def test_aplanar_lista_basica():
@@ -138,3 +140,17 @@ def test_list_con_datos_inicializados(datos_inicializados):
     datos_inicializados["elementos"].append(2)
     datos_inicializados["elementos"].append(3)
     assert len(datos_inicializados["elementos"]) == 3
+
+
+@pytest.mark.skipif(
+    os.getenv('PERFORMANCE_TESTS') != 'enabled',
+    reason="Por el momento tests de rendimiento deshabilitados"
+)
+def test_rendimiento_filtrar_patron_grandes():
+    archivos_grandes = [f"archivo_{i}.py" for i in range(100000)]
+    archivos_grandes.extend([f"test_{i}.py" for i in range(50000)])
+    inicio = time.perf_counter()
+    resultado = list_utils.filtrar_por_patron(archivos_grandes, r"^test_")
+    duracion = time.perf_counter() - inicio
+    assert len(resultado) == 50000
+    assert duracion < 5.5

--- a/tests/test_list_utils.py
+++ b/tests/test_list_utils.py
@@ -154,3 +154,32 @@ def test_rendimiento_filtrar_patron_grandes():
     duracion = time.perf_counter() - inicio
     assert len(resultado) == 50000
     assert duracion < 5.5
+
+
+@pytest.mark.xfail(reason="Aun no se agrupa archivos por varios criterios")
+def test_agrupar_por_multiples_criterios(self):
+    archivos = [
+        "src/list_utils.py",
+        "iac/main.tf",
+        "src/logs/registrador_logs.py",
+        "tests/test_list_utils.py"
+    ]
+
+    resultado = list_utils.agrupar_por_extension(
+        archivos,
+        criterios=['directorio', 'extension']
+    )
+
+    assert 'src' in resultado
+    assert '.py' in resultado['src']
+    assert "src/list_utils.py" in resultado['src']['.py']
+    assert "src/logs/registrador_logs.py" in resultado['src']['.py']
+    assert len(resultado['src']['.py']) == 2
+
+    assert 'iac' in resultado
+    assert '.tf' in resultado['iac']
+    assert "iac/main.tf" in resultado['iac']['.tf']
+
+    assert 'tests' in resultado
+    assert '.py' in resultado['tests']
+    assert "tests/test_list_utils.py" in resultado['tests']['.py']

--- a/tests/test_string_utils_con_mock.py
+++ b/tests/test_string_utils_con_mock.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, Mock, create_autospec
 import re
 import os
 import platform
+import sys
 from src.utils.string_utils import (
     extraer_metricas_de_output,
     parsear_ruta_archivo,
@@ -96,15 +97,21 @@ class TestConSkip:
 
 
 class TestConXFail:
-
-    @pytest.mark.xfail(
-        platform.system() == "Windows",
-        reason="Windows limita rutas a maximo con 260 caracteres",
-        strict=False
-    )
-    def test_ruta_larga_windows(self):
-        carpeta = "r" * 250
-        ruta_larga = os.path.join("C:\\", carpeta, "archivo.py")
-        resultado = parsear_ruta_archivo(ruta_larga)
-        assert resultado['nombre_archivo'] == "archivo.py"
-        assert resultado['nivel_profundidad'] > 0
+    @pytest.mark.xfail(reason="Aun no se parsean multiples rutas con agrupacion")
+    def test_parsear_multiples_rutas_agrupadas(self):
+        rutas_proyecto = [
+            "src/utils/string_utils.py",
+            "src/utils/list_utils.py",
+            "tests/test_string_utils.py", 
+            "tests/test_list_utils.py",
+            "iac/main.tf",
+            "iac/variables.tf"
+        ]    
+        resultado = parsear_ruta_archivo(
+            rutas_proyecto,
+            criterios=['directorio_raiz', 'tipo_archivo', 'es_test']
+        )
+        assert 'src' in resultado
+        assert 'python' in resultado['src']
+        assert 'no_test' in resultado['src']['python']
+        assert len(resultado['src']['python']['no_test']) == 2

--- a/tests/test_string_utils_con_mock.py
+++ b/tests/test_string_utils_con_mock.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import patch, Mock, create_autospec
 import re
 import os
+import platform
 from src.utils.string_utils import (
     extraer_metricas_de_output,
     parsear_ruta_archivo,
@@ -92,3 +93,18 @@ class TestConSkip:
         resultado = extraer_metricas_de_output(log_prod)
         assert resultado['errors'] == 3
         assert resultado['duration'] == 41.2
+
+
+class TestConXFail:
+
+    @pytest.mark.xfail(
+        platform.system() == "Windows",
+        reason="Windows limita rutas a maximo con 260 caracteres",
+        strict=False
+    )
+    def test_ruta_larga_windows(self):
+        carpeta = "r" * 250
+        ruta_larga = os.path.join("C:\\", carpeta, "archivo.py")
+        resultado = parsear_ruta_archivo(ruta_larga)
+        assert resultado['nombre_archivo'] == "archivo.py"
+        assert resultado['nivel_profundidad'] > 0

--- a/tests/test_string_utils_con_mock.py
+++ b/tests/test_string_utils_con_mock.py
@@ -17,11 +17,9 @@ class TestExtraerMetricasConMock:
         mock_match = Mock()
         mock_match.group.return_value = "15"
         mock_search.return_value = mock_match
-
         metricas = extraer_metricas_de_output("15 passed tests")
         assert metricas['tests_passed'] == 15
         assert mock_search.call_count >= 1
-
         calls = mock_search.call_args_list
         patron_calls = [call[0][0] for call in calls]
         assert any('passed' in patron for patron in patron_calls)
@@ -33,7 +31,6 @@ class TestParsearRutaConMock:
     @patch.object(os.path, 'basename')
     @patch.object(os.path, 'dirname')
     @patch.object(os.path, 'splitext')
-    @patch.object(os, 'sep', '\\')  # windows
     def test_parsear_ruta_windows(self, mock_splitext, mock_dirname,
                                   mock_basename, mock_normpath):
         mock_normpath.return_value = "src\\utils\\string_utils.py"
@@ -76,3 +73,22 @@ class TestProcesarSalidaHerramientaConMock:
                 assert resultado['estado'] == 'warning'
                 assert resultado['metricas'] == {'warnings': 5}
                 assert resultado['salida_limpia'] == "clean output"
+
+
+class TestConSkip:
+
+    @pytest.mark.skip(reason="Aun no se extrae metricas en formato xml")
+    def test_extraer_metricas_formato_xml(self):
+        xml_output = "<package name=utils line-rate=0.9709>"
+        resultado = extraer_metricas_de_output(xml_output)
+        assert resultado['coverage_percent'] == "97.09%"
+
+    @pytest.mark.skipif(
+        os.getenv('CI_ENVIRONMENT') != 'production',
+        reason="Solo se ejecuta en entorno de produccion"
+    )
+    def test_procesar_logs_produccion(self):
+        log_prod = "700 requests processed, 3 errors, 41.2 seconds"
+        resultado = extraer_metricas_de_output(log_prod)
+        assert resultado['errors'] == 3
+        assert resultado['duration'] == 41.2


### PR DESCRIPTION
## Descripcion
Se implementa tests con marcas xfail y skip en casos especificos que dependan de variables de entorno faltantes, errores para determinadas plataformas, funcionalidades aun no implementadas.

## Cambios Realizados
- Se agrega tests con marcas xfail y skip en test_list_utils.py 
- Se agrega tests con marcas xfail y skip en test_string_utils_con_mock.py

Esta PR completa la Issue #23 