### PR TITLE
feat: se modifica lint_qa.sh con tflint y flake8 para errores criticos

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -2,7 +2,7 @@
 STAGED=$(git diff --cached --name-only) #obtiene los archivos que estan preparados para el commit
 
 for file in $STAGED; do
-    if [[ ! $file =~ \.(py|sh|tf|tfvars|md|svg|txt)$ && $file == *.* && $file != ".gitignore" ]]; then #verifica que los archivos tengan una extension permitida, permite .gitignore
+    if [[ ! $file =~ \.(py|sh|tf|tfvars|md|svg|txt)$ && $file != "iac/.tflint.hcl" && $file == *.* && $file != ".gitignore" ]]; then #verifica que los archivos tengan una extension permitida, permite .gitignore, permite .tflint.hcl
         echo "Solo se permiten archivos .py, .sh, .tf, .tfvars, .md, .svg .txt: $file"
         exit 1
     fi

--- a/iac/.tflint.hcl
+++ b/iac/.tflint.hcl
@@ -1,0 +1,27 @@
+plugin "terraform" {
+  enabled = true
+}
+
+rule "terraform_deprecated_interpolation" {
+  enabled = true  
+}
+
+rule "terraform_deprecated_index" {
+  enabled = true 
+}
+
+rule "terraform_unused_declarations" {
+  enabled = true
+}
+
+rule "terraform_comment_syntax" {
+  enabled = true
+}
+
+rule "terraform_required_version" {
+  enabled = true
+}
+
+rule "terraform_required_providers" {
+  enabled = true
+}

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0.0"
+    }
+  }
+}
+
 # Recurso null_resource
 resource "null_resource" "qa_platform_setup" {
   triggers = {

--- a/scripts/lint_qa.sh
+++ b/scripts/lint_qa.sh
@@ -7,7 +7,12 @@ for dir in src/ scripts/ iac/; do
     fi
 done
 
-echo "Ejecutando flake8 en src/"
+echo "Ejecutando flake8 --select para encontrar errores criticos en src/"
+if ! flake8 --select=E9,F63,F7,F82 --show-source src/; then
+    exit 1
+fi
+
+echo "Ejecutando flake8 para estilo de codigo en src/"
 if ! flake8 src/; then
     exit 1
 fi
@@ -25,6 +30,22 @@ echo "Ejecutando terraform fmt -check en iac/"
 cd iac/ || { echo "Error: No se pudo entrar al directorio iac/"; exit 1; }
 if ! terraform fmt -check; then
     exit 1
+fi
+
+echo "Ejecutando tflint en iac/"
+if ! command -v tflint &> /dev/null; then
+    echo "Advertencia: tflint no esta instalado, omitiendo validacion"
+else
+    if [ -f ".tflint.hcl" ]; then
+        if ! tflint; then
+            exit 1
+        fi
+    else
+        echo "Advertencia: No existe .tflint.hcl, ejecutando tflint basico"
+        if ! tflint; then
+            exit 1
+        fi
+    fi
 fi
 cd ..
 


### PR DESCRIPTION
## Descripcion
Se modifica lint_qa.sh para incluir tflint en modo local con las reglas definidas en .tflint.hcl  y flake8 para errores criticos. Ademas Se corrige errores en main.tf para correcta validacion de tflint

## Cambios Realizados
- Se creo .tflint.hcl  en iac/
- Se modifica lint_qa.sh
- Se modifica pre-commit para poder subir modificaciones de .tflint.hcl

Este PR finaliza la Issue #46 